### PR TITLE
Enhance `wrap` type infer

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+tests/result.test-d.ts

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you have a synchronous function, you can simply wrap your function and call
 it later on.
 
 ```ts
-import { wrap } from 'unwrapit'
+import {wrap} from 'unwrapit'
 
 const tryParseJson = wrap(() => JSON.parse(`{"package": "unwrapit!"}`))
 // unwrap to get the value without checking if it could be failed.
@@ -36,13 +36,13 @@ import {wrap} from 'unwrapit'
 
 const fetchWrapper = wrap(fetch)
 const ret = (await fetchWrapper('www.google.com')).unwrap()
-const json = await ret.json())
+const json = await ret.json()
 ```
 
 You can wrap a promise value as well.
 
 ```ts
-import { wrap } from 'unwrapit'
+import {wrap} from 'unwrapit'
 
 const promise = new Promise<string>((resolve, reject) => {
   if (Math.random() < 0.5) return resolve('Yay')
@@ -59,7 +59,7 @@ Normally, you should check your value if succeed or not, then handle your
 errors. In this case, you can do this
 
 ```ts
-import { wrap } from 'unwrapit'
+import {wrap} from 'unwrapit'
 
 const promise = new Promise<string>((resolve, reject) => {
   if (Math.random() < 0.5) return resolve('Yay')
@@ -82,8 +82,8 @@ Normally, you can just simply `wrap` your function, it has `wrap`ped with Result
 automatically. But you still can use Result manually.
 
 ```ts
-import { ok, err } from 'unwrapit'
-import type { Result } from 'unwrapit'
+import {ok, err} from 'unwrapit'
+import type {Result} from 'unwrapit'
 
 const pass: Result<number, never> = ok(1)
 const fail: Result<never, string> = err('error')
@@ -103,18 +103,18 @@ If you are using `rxjs`, you can use the built-in operator `toWrap` to wrap the
 result into `Result` type.
 
 ```ts
-import { from, map } from 'rxjs'
-import { toWrap } from 'unwrapit'
+import {from, map} from 'rxjs'
+import {toWrap} from 'unwrapit'
 
 from([1, 2, 3])
   .pipe(
-    map((x) => {
+    map(x => {
       if (x % 2 === 0) throw new Error(`num ${x} is even.`)
       return x
     }),
     toWrap()
   )
-  .subscribe((x) => {
+  .subscribe(x => {
     if (!x.ok) return console.error(x.error) // Error: num 2 is even.
     console.log(x.value)
   })
@@ -183,8 +183,8 @@ By default, it will use the `panic` from
 Here's an example
 
 ```ts
-import { setPanic } from 'unwrapit'
-import type { Panic } from 'unwrapit'
+import {setPanic} from 'unwrapit'
+import type {Panic} from 'unwrapit'
 
 class MyError extends Error {}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,9 @@
-import {panic as defaultPanic} from 'panicit'
+import {panic as defaultPanic} from 'panicit';
+
+export type Panic = (
+  message: any,
+  opt?: {cause?: any; shouldExit?: boolean}
+) => never
 
 export type TWrapConfig = {
   /**
@@ -8,7 +13,7 @@ export type TWrapConfig = {
   /**
    * Customize `panic` function. By default will use `panic` from `panicit`.
    */
-  panicFn: typeof defaultPanic
+  panicFn: Panic
 }
 
 export const WrapConfig: TWrapConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export {panic} from 'panicit'
-export {defineWrapConfig, type TWrapConfig as WrapConfig} from './config'
+export {defineWrapConfig} from './config'
+export type {Panic, TWrapConfig as WrapConfig} from './config'
 export {err, ok, setPanic, wrap} from './result'
 export type {Result, WrapOption} from './result'
 export {toWrap} from './toWrap'
-export type {TF, TP, TR} from './types'

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,18 +28,3 @@ export type TR<T extends (...args: any) => any> = T extends (
     ? P
     : R
   : any
-
-/**
- * Resolve the parameter type and return type of a function.
- *
- * # Example
- *
- * ```ts
- * declare function foo(a: number): string
- * type t1 = TF<typeof foo> // [[a: number], string]
- *
- * declare function bar(a: number): Promise<string>
- * type t2 = TF<typeof bar> // [[a: number], string]
- * ```
- */
-export type TF<T extends (...args: any) => any> = [TP<T>, TR<T>]

--- a/tests/result.test-d.ts
+++ b/tests/result.test-d.ts
@@ -1,6 +1,5 @@
 import {describe, expectTypeOf, test} from 'vitest'
 import {Err, Ok, Result, WrapOption, err, ok, wrap} from '../src/result'
-import {TF} from '../src/types'
 
 describe('Result types test', () => {
   test('ok type', () => {
@@ -9,15 +8,9 @@ describe('Result types test', () => {
     expectTypeOf(ok('string')).toEqualTypeOf<Result<string, never>>()
     expectTypeOf(ok(1).unwrap).toMatchTypeOf<(opts?: WrapOption) => number>()
     expectTypeOf(ok(1).unwrapOr).toEqualTypeOf<(v: number) => number>()
-    expectTypeOf(ok(1).unwrapOrElse(e => 'string')).toEqualTypeOf<
-      string | number
-    >()
-    expectTypeOf(
-      (ok(1) as Ok<number>).unwrapOrElse(e => '1')
-    ).toEqualTypeOf<number>()
-    expectTypeOf(ok(1).expect).toMatchTypeOf<
-      (arg: string, opts?: WrapOption) => number
-    >()
+    expectTypeOf(ok(1).unwrapOrElse(e => 'string')).toEqualTypeOf<string | number>()
+    expectTypeOf((ok(1) as Ok<number>).unwrapOrElse(e => '1')).toEqualTypeOf<number>()
+    expectTypeOf(ok(1).expect).toMatchTypeOf<(arg: string, opts?: WrapOption) => number>()
   })
 
   test('err type', () => {
@@ -25,73 +18,84 @@ describe('Result types test', () => {
     expectTypeOf(err(1)).toEqualTypeOf<Result<unknown, number>>()
     expectTypeOf(err('string')).toEqualTypeOf<Result<unknown, string>>()
     expectTypeOf(err(new Error())).toEqualTypeOf<Result<unknown, Error>>()
-    expectTypeOf((err(1) as Err<number, string>).unwrap).toMatchTypeOf<
-      (opts?: WrapOption) => never
-    >()
-    expectTypeOf((err(1) as Err<number, string>).unwrapOr).toEqualTypeOf<
-      (v: string) => string
-    >()
-    expectTypeOf((err(1) as Err<number, string>).unwrapOrElse).toEqualTypeOf<
-      <U>(mapFn: (e: number) => U) => U
-    >()
-    expectTypeOf((err(1) as Err<number, string>).expect).toMatchTypeOf<
-      (errorMessage: string, opts?: WrapOption) => never
-    >()
-    expectTypeOf(err(1).mapErr).toMatchTypeOf<
-      <U>(errMapFn: (e: number) => U) => Result<unknown, U>
-    >()
+    expectTypeOf((err(1) as Err<number, string>).unwrap).toMatchTypeOf<(opts?: WrapOption) => never>()
+    expectTypeOf((err(1) as Err<number, string>).unwrapOr).toEqualTypeOf<(v: string) => string>()
+    expectTypeOf((err(1) as Err<number, string>).unwrapOrElse).toEqualTypeOf<<U>(mapFn: (e: number) => U) => U>()
+    expectTypeOf((err(1) as Err<number, string>).expect).toMatchTypeOf<(errorMessage: string, opts?: WrapOption) => never>()
+    expectTypeOf(err(1).mapErr).toMatchTypeOf<<U>(errMapFn: (e: number) => U) => Result<unknown, U>>()
   })
 
-  describe('wrap type', () => {
-    test('async functions', () => {
-      async function foo(a: number, b: boolean): Promise<string> {
-        return ''
-      }
+  test('wrap type', () => {
+    const sf1 = (): any => 1
+    const sf2 = (): string => ''
+    const sf3 = (a: number, b: boolean): any => 1
+    const sf4 = (a: number, b: boolean): string => ''
 
-      expectTypeOf(wrap(foo)).toEqualTypeOf<
-        (a: number, b: boolean) => Promise<Result<string, unknown>>
-      >()
-      expectTypeOf(wrap<Error, TF<typeof foo>>(foo)).toEqualTypeOf<
-        (a: number, b: boolean) => Promise<Result<string, Error>>
-      >()
-    })
+    const af1 = async (): Promise<any> => {}
+    const af2 = async (): Promise<string> => ''
+    const af3 = async (a: number, b: boolean): Promise<any> => {}
+    const af4 = async (a: number, b: boolean): Promise<string> => ''
+    
+    // implicitly infer
+    expectTypeOf(wrap(sf1)).toEqualTypeOf<() => Result<any, unknown>>()
+    expectTypeOf(wrap(sf2)).toEqualTypeOf<() => Result<string, unknown>>()
+    expectTypeOf(wrap(sf3)).toEqualTypeOf<(a: number, b: boolean) => Result<any, unknown>>()
+    expectTypeOf(wrap(sf4)).toEqualTypeOf<(a: number, b: boolean) => Result<string, unknown>>()
 
-    test('sync functions', () => {
-      function foo(a: number, b: boolean): string {
-        return ''
-      }
+    expectTypeOf(wrap(af1)).toEqualTypeOf<() => Promise<Result<any, unknown>>>()
+    expectTypeOf(wrap(af2)).toEqualTypeOf<() => Promise<Result<string, unknown>>>()
+    expectTypeOf(wrap(af3)).toEqualTypeOf<(a: number, b: boolean) => Promise<Result<any, unknown>>>()
+    expectTypeOf(wrap(af4)).toEqualTypeOf<(a: number, b: boolean) => Promise<Result<string, unknown>>>()
 
-      expectTypeOf(wrap(foo)).toEqualTypeOf<
-        (a: number, b: boolean) => Result<string, unknown>
-      >()
-      expectTypeOf(wrap<Error, TF<typeof foo>>(foo)).toEqualTypeOf<
-        (a: number, b: boolean) => Result<string, Error>
-      >()
-    })
+    // specify error type
+    expectTypeOf(wrap<Error, typeof sf1>(sf1)).toEqualTypeOf<() => Result<any, Error>>()
+    expectTypeOf(wrap<string[], typeof sf1>(sf1)).toEqualTypeOf<() => Result<any, string[]>>()
+    expectTypeOf(wrap<Error, typeof sf2>(sf2)).toEqualTypeOf<() => Result<string, Error>>()
+    expectTypeOf(wrap<Error, typeof sf3>(sf3)).toEqualTypeOf<(a: number, b: boolean) => Result<any, Error>>()
+    expectTypeOf(wrap<Error, typeof sf4>(sf4)).toEqualTypeOf<(a: number, b: boolean) => Result<string, Error>>()
 
-    test('promise values', () => {
-      expectTypeOf(wrap(Promise.resolve(1))).toEqualTypeOf<
-        Promise<Result<number, unknown>>
-      >()
-      expectTypeOf(wrap<Error, number>(Promise.resolve(1))).toEqualTypeOf<
-        Promise<Result<number, Error>>
-      >()
-      expectTypeOf(wrap(Promise.reject(1))).toEqualTypeOf<
-        Promise<Result<never, unknown>>
-      >()
-    })
+    expectTypeOf(wrap<Error, typeof af1>(af1)).toEqualTypeOf<() => Promise<Result<any, Error>>>()
+    expectTypeOf(wrap<string[], typeof af1>(af1)).toEqualTypeOf<() => Promise<Result<any, string[]>>>()
+    expectTypeOf(wrap<Error, typeof af2>(af2)).toEqualTypeOf<() => Promise<Result<string, Error>>>()
+    expectTypeOf(wrap<Error, typeof af3>(af3)).toEqualTypeOf<(a: number, b: boolean) => Promise<Result<any, Error>>>()
+    expectTypeOf(wrap<Error, typeof af4>(af4)).toEqualTypeOf<(a: number, b: boolean) => Promise<Result<string, Error>>>()
 
-    test('arbitrary values', () => {
-      expectTypeOf(wrap(1)).toEqualTypeOf<Result<number, never>>()
-      expectTypeOf(wrap('string')).toEqualTypeOf<Result<string, never>>()
-      expectTypeOf(wrap([1, 2, 3])).toEqualTypeOf<Result<number[], never>>()
-      expectTypeOf(wrap({a: 1, b: true})).toEqualTypeOf<
-        Result<{a: number; b: boolean}, never>
-      >()
-      expectTypeOf(wrap(new Error())).toEqualTypeOf<Result<Error, never>>()
+    // specify error & return type
+    expectTypeOf(wrap<Error, typeof sf1, number>(sf1)).toEqualTypeOf<() => Result<number, Error>>()
+    expectTypeOf(wrap<Error, typeof sf1, string>(sf1)).toEqualTypeOf<() => Result<string, Error>>()
+    expectTypeOf(wrap<Error, typeof sf2, 'a'>(sf2)).toEqualTypeOf<() => Result<'a', Error>>()
+    expectTypeOf(wrap<Error, typeof sf3, number>(sf3)).toEqualTypeOf<(a: number, b: boolean) => Result<number, Error>>()
+    expectTypeOf(wrap<Error, typeof sf4, 'a'>(sf4)).toEqualTypeOf<(a: number, b: boolean) => Result<'a', Error>>()
+    // @ts-expect-error
+    expectTypeOf(wrap<Error, typeof sf2, number>(sf3)).toEqualTypeOf<(a: number, b: boolean) => Result<string, Error>>()
+    // @ts-expect-error
+    expectTypeOf(wrap<Error, typeof sf4, number>(sf3)).toEqualTypeOf<(a: number, b: boolean) => Result<number, Error>>()
 
-      // @ts-expect-error
-      expectTypeOf(wrap<string>(1)).toEqualTypeOf<Result<string, never>>()
-    })
+    expectTypeOf(wrap<Error, typeof af1, Promise<number>>(af1)).toEqualTypeOf<() => Promise<Result<number, Error>>>()
+    expectTypeOf(wrap<Error, typeof af1, Promise<string>>(af1)).toEqualTypeOf<() => Promise<Result<string, Error>>>()
+    expectTypeOf(wrap<Error, typeof af2, Promise<'a'>>(af2)).toEqualTypeOf<() => Promise<Result<'a', Error>>>()
+    expectTypeOf(wrap<Error, typeof af3, Promise<number>>(af3)).toEqualTypeOf<(a: number, b: boolean) => Promise<Result<number, Error>>>()
+    expectTypeOf(wrap<Error, typeof af4, Promise<'a'>>(af4)).toEqualTypeOf<(a: number, b: boolean) => Promise<Result<'a', Error>>>()
+    // @ts-expect-error
+    expectTypeOf(wrap<Error, typeof af1, number>(af1)).toEqualTypeOf<() => Promise<Result<number, Error>>>()
+    // @ts-expect-error
+    expectTypeOf(wrap<Error, typeof af2, Promise<number>>(af2)).toEqualTypeOf<() => Promise<Result<number, Error>>>()
+    // @ts-expect-error
+    expectTypeOf(wrap<Error, typeof af4, Promise<number>>(af4)).toEqualTypeOf<() => Promise<Result<number, Error>>>()
+  })
+
+  test('wrap arbitrary values', () => {
+    expectTypeOf(wrap(Promise.resolve(1))).toEqualTypeOf<Promise<Result<number, unknown>>>()
+    expectTypeOf(wrap<Error, number>(Promise.resolve(1))).toEqualTypeOf<Promise<Result<number, Error>>>()
+    expectTypeOf(wrap(Promise.reject(1))).toEqualTypeOf<Promise<Result<never, unknown>>>()
+
+    expectTypeOf(wrap(1)).toEqualTypeOf<Result<number, never>>()
+    expectTypeOf(wrap('string')).toEqualTypeOf<Result<string, never>>()
+    expectTypeOf(wrap([1, 2, 3])).toEqualTypeOf<Result<number[], never>>()
+    expectTypeOf(wrap({a: 1, b: true})).toEqualTypeOf<Result<{a: number; b: boolean}, never>>()
+    expectTypeOf(wrap(new Error())).toEqualTypeOf<Result<Error, never>>()
+
+    // @ts-expect-error
+    expectTypeOf(wrap<string>(1)).toEqualTypeOf<Result<string, never>>()
   })
 })


### PR DESCRIPTION
The `wrap` function now can infer the correct type based on whatever users pass in.

## Infer type automatically

```ts
declare function fn(): string

const f = wrap(fn)
//    ^? const f: () => Result<string, unknown>
```

## Specify error type

```ts
declare function fn(): string

const f = wrap<Error, typeof fn>(fn)
//    ^? const f: () => Result<string, Error>
```

## Specify both error and return type

This is useful when you want to narrow down a function that returns any type

```ts
declare function fn(): any

const f = wrap<Error, typeof fn, number>(fn)
//    ^? const f: () => Result<number, Error>
```

## Promise infer

The above function can infer Promise return as well

```ts
declare function fn(): Promise<string>

const f = wrap(fn)
//    ^? const f: () => Promise<Result<string, unknown>>
```

```ts
declare function fn(): Promise<string>

const f = wrap<Error, typeof fn>(fn)
//    ^? const f: () => Promise<Result<string, Error>>
```

```ts
declare function fn(): Promise<any>

const f = wrap<Error, typeof fn, number>(fn)
//    ^? const f: () => Promise<Result<number, Error>>
```